### PR TITLE
UIScrollView+Combine

### DIFF
--- a/Example/Example/ControlsViewController.swift
+++ b/Example/Example/ControlsViewController.swift
@@ -49,7 +49,9 @@ class ControlsViewController: UIViewController {
                    rightBarButtonItem.tapPublisher.map { "Tapped Right Bar Button Item" })
       .merge(with: leftSwipe.swipePublisher.map { "Swiped Left with Gesture \($0.memoryAddress)" },
                    longPress.longPressPublisher.map { "Long Pressed with Gesture \($0.memoryAddress)" },
-                   doubleTap.tapPublisher.map { "Double-tapped view with two fingers with Gesture \($0.memoryAddress)" })
+                   doubleTap.tapPublisher.map { "Double-tapped view with two fingers with Gesture \($0.memoryAddress)" },
+                   console.contentOffsetPublisher.map { "Content offset is \($0)" },
+                   console.reachedBottomPublisher().map { _ in "Reached the bottom of the UITextView" })
       .scan("") { $0 + "\n" + $1 }
       .handleEvents(receiveOutput: { [console] text in
         guard let console = console else { return }

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ swipeGesture.swipePublisher // AnyPublisher<UISwipeGestureRecognizer, Never>
 panGesture.panPublisher // AnyPublisher<UIPanGestureRecognizer, Never>
 screenEdgePanGesture.screenEdgePanPublisher // AnyPublisher<UIScreenEdgePanGestureRecognizer, Never>
 longPressGesture.longPressPublisher // AnyPublisher<UILongPressGestureRecognizer, Never>
+scrollView.contentOffsetPublisher // AnyPublisher<CGPoint, Never>
+scrollView.reachedBottomPublisher(offset:) // AnyPublisher<Void, Never>
 ```
 
 ## Installation

--- a/Sources/Controls/UIScrollView+Combine.swift
+++ b/Sources/Controls/UIScrollView+Combine.swift
@@ -14,4 +14,22 @@ public extension UIScrollView {
         publisher(for: \.contentOffset)
             .eraseToAnyPublisher()
     }
+
+    /// A publisher emitting if the bottom of the UIScrollView is reached.
+    ///- parameter offset: A threshhold indicating the bottom of the UIScrollView. Default 0.0.
+    ///- returns: AnyPublisher that emits when the bottom of the UIScrollView is reached.
+    func reachedBottomPublisher(offset: CGFloat = 0.0) -> AnyPublisher<Void, Never> {
+        contentOffsetPublisher
+            .map { [weak self] contentOffset -> Bool in
+                guard let self = self else { return false }
+                let visibleHeight = self.frame.height - self.contentInset.top - self.contentInset.bottom
+                let y = contentOffset.y + self.contentInset.top
+                let threshold = max(offset, self.contentSize.height - visibleHeight)
+                return y > threshold
+            }
+            .removeDuplicates()
+            .filter { $0 }
+            .map { _ in () }
+            .eraseToAnyPublisher()
+    }
 }

--- a/Sources/Controls/UIScrollView+Combine.swift
+++ b/Sources/Controls/UIScrollView+Combine.swift
@@ -2,7 +2,8 @@
 //  UIScrollView+Combine.swift
 //  CombineCocoa
 //
-//  Created by Joan Disho on 09.08.19.
+//  Created by Joan Disho on 09/08/2019.
+//  Copyright © 2019 Shai Mishali. All rights reserved.
 //
 
 import Foundation
@@ -16,9 +17,11 @@ public extension UIScrollView {
     }
 
     /// A publisher emitting if the bottom of the UIScrollView is reached.
-    ///- parameter offset: A threshhold indicating the bottom of the UIScrollView. Default 0.0.
-    ///- returns: AnyPublisher that emits when the bottom of the UIScrollView is reached.
-    func reachedBottomPublisher(offset: CGFloat = 0.0) -> AnyPublisher<Void, Never> {
+    ///
+    /// - parameter offset: A threshold indicating how close to the bottom of the UIScrollView this publisher should emit.
+    ///                     Defaults to 0
+    /// - returns: A publisher that emits when the bottom of the UIScrollView is reached within the provided threshold.
+    func reachedBottomPublisher(offset: CGFloat = 0) -> AnyPublisher<Void, Never> {
         contentOffsetPublisher
             .map { [weak self] contentOffset -> Bool in
                 guard let self = self else { return false }

--- a/Sources/Controls/UIScrollView+Combine.swift
+++ b/Sources/Controls/UIScrollView+Combine.swift
@@ -1,0 +1,17 @@
+//
+//  UIScrollView+Combine.swift
+//  CombineCocoa
+//
+//  Created by Joan Disho on 09.08.19.
+//
+
+import Foundation
+import Combine
+
+public extension UIScrollView {
+    /// A publisher emitting content offset changes from this UIScrollView.
+    var contentOffsetPublisher: AnyPublisher<CGPoint, Never> {
+        publisher(for: \.contentOffset)
+            .eraseToAnyPublisher()
+    }
+}


### PR DESCRIPTION
I am not sure if this extension is relevant to this lib, but is worth trying 😊

1. Creating `contentOffsetPublisher` just because of [`contentOffset` in RxCocoa](https://github.com/ReactiveX/RxSwift/blob/6b2a406b928cc7970874dcaed0ab18e7265e41ef/RxCocoa/iOS/UIScrollView%2BRx.swift#L26)
2. Creating `reachedBottomPublisher(offset:)`, which is a publisher, emitting if the bottom of the `UIScrollView` is reached. Similar to what we have in [RxSwiftExt](https://github.com/RxSwiftCommunity/RxSwiftExt/blob/master/Source/RxCocoa/UIScrollView%2BreachedBottom.swift)